### PR TITLE
Add loading skeleton for event type page with placeholder navigation

### DIFF
--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-page.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { EventTypeWebWrapper } from "@calcom/atoms/event-types/wrappers/EventTypeWebWrapper";
-import { Shell } from "@calcom/features/shell/Shell";
+import Shell from "@calcom/features/shell/Shell";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { VerticalTabs } from "@calcom/ui/components/navigation";
 import type { VerticalTabItemProps } from "@calcom/ui/components/navigation";
@@ -33,7 +33,7 @@ export default function EventTypePage({ id, data }: EventTypePageProps) {
     {
       name: t("limits"),
       href: `/event-types/${id}?tabName=limits`,
-      icon: "sliders",
+      icon: "sliders-horizontal",
       info: t("how_often_you_can_be_booked"),
     },
     {
@@ -51,7 +51,7 @@ export default function EventTypePage({ id, data }: EventTypePageProps) {
     {
       name: t("apps"),
       href: `/event-types/${id}?tabName=apps`,
-      icon: "grid",
+      icon: "grid-3x3",
       info: t("0_apps_0_active", { count: 0, active: 0 }),
     },
     {

--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-page.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { EventTypeWebWrapper } from "@calcom/atoms/event-types/wrappers/EventTypeWebWrapper";
+import { Shell } from "@calcom/features/shell/Shell";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { VerticalTabs } from "@calcom/ui/components/navigation";
+import type { VerticalTabItemProps } from "@calcom/ui/components/navigation";
+
+interface EventTypePageProps {
+  id: number;
+  data: any; // Replace with proper type
+}
+
+export default function EventTypePage({ id, data }: EventTypePageProps) {
+  const { t } = useLocale();
+  const [activeTab, setActiveTab] = useState<string>("setup");
+
+  const tabsNavigation: VerticalTabItemProps[] = [
+    {
+      name: t("event_setup"),
+      href: `/event-types/${id}?tabName=setup`,
+      icon: "calendar",
+      info: t("15_mins"),
+    },
+    {
+      name: t("availability"),
+      href: `/event-types/${id}?tabName=availability`,
+      icon: "clock",
+      info: t("working_hours"),
+    },
+    {
+      name: t("limits"),
+      href: `/event-types/${id}?tabName=limits`,
+      icon: "sliders",
+      info: t("how_often_you_can_be_booked"),
+    },
+    {
+      name: t("advanced"),
+      href: `/event-types/${id}?tabName=advanced`,
+      icon: "settings",
+      info: t("calendar_settings_and_more"),
+    },
+    {
+      name: t("recurring"),
+      href: `/event-types/${id}?tabName=recurring`,
+      icon: "repeat",
+      info: t("set_up_a_repeating_schedule"),
+    },
+    {
+      name: t("apps"),
+      href: `/event-types/${id}?tabName=apps`,
+      icon: "grid",
+      info: t("0_apps_0_active", { count: 0, active: 0 }),
+    },
+    {
+      name: t("workflows"),
+      href: `/event-types/${id}?tabName=workflows`,
+      icon: "zap",
+      info: t("0_active", { count: 0 }),
+    },
+    {
+      name: t("webhooks"),
+      href: `/event-types/${id}?tabName=webhooks`,
+      icon: "link",
+      info: t("0_active", { count: 0 }),
+    },
+  ];
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const tabName = urlParams.get("tabName");
+    if (tabName) {
+      setActiveTab(tabName);
+    }
+  }, []);
+
+  return (
+    <Shell
+      title={`${data?.eventType?.title || ""} | ${t("event_type")}`}
+      heading={data?.eventType?.title || ""}
+      subtitle={t("manage_event_type_settings")}
+      backPath="/event-types">
+      <div className="flex flex-col xl:flex-row xl:space-x-6">
+        <div className="hidden xl:block">
+          <VerticalTabs
+            className="primary-navigation w-64"
+            tabs={tabsNavigation}
+            sticky
+            linkShallow
+            itemClassname="items-start"
+          />
+        </div>
+        <div className="w-full ltr:mr-2 rtl:ml-2">
+          <div className="bg-default border-subtle mt-4 rounded-md sm:mx-0 md:border md:p-6 xl:mt-0">
+            <EventTypeWebWrapper id={id} data={data} />
+          </div>
+        </div>
+      </div>
+    </Shell>
+  );
+}

--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-skeleton.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-skeleton.tsx
@@ -2,17 +2,42 @@
 
 import Shell from "@calcom/features/shell/Shell";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import { SkeletonContainer, SkeletonText, SkeletonAvatar } from "@calcom/ui/components/skeleton";
+import {
+  SkeletonContainer,
+  SkeletonText,
+  SkeletonAvatar,
+  SkeletonButton,
+} from "@calcom/ui/components/skeleton";
 
 export default function EventTypeSkeleton() {
   const { t } = useLocale();
 
+  const backButtonSkeleton = (
+    <div className="bg-default sticky top-0 z-10 mb-0 flex items-center py-2 md:mb-6 md:mt-0">
+      <div className="rounded-md ltr:mr-2 rtl:ml-2">
+        <SkeletonButton className="h-8 w-8 rounded-md" />
+      </div>
+      <div className="w-full truncate ltr:mr-4 rtl:ml-4 md:block">
+        <SkeletonText className="h-8 w-48" />
+        <SkeletonText className="mt-1 h-4 w-24" />
+      </div>
+      <div className="flex items-center gap-2">
+        <SkeletonButton className="h-9 w-9 rounded-md" />
+        <SkeletonButton className="h-9 w-9 rounded-md" />
+        <div className="flex space-x-2 rtl:space-x-reverse">
+          <SkeletonButton className="h-9 w-24 rounded-md" />
+          <SkeletonButton className="h-9 w-24 rounded-md" />
+        </div>
+      </div>
+    </div>
+  );
+
   return (
     <Shell
       title={t("event_type_skeleton")}
-      heading={<SkeletonText className="h-8 w-48" />}
-      subtitle={<SkeletonText className="h-4 w-24" />}
-      backPath="/event-types">
+      heading={<SkeletonText className="hidden h-8 w-48" />}
+      subtitle={<SkeletonText className="hidden h-4 w-24" />}
+      afterHeading={backButtonSkeleton}>
       <div className="flex flex-col xl:flex-row xl:space-x-6">
         <div className="hidden xl:block">
           <div className="primary-navigation w-64 flex-shrink-0">
@@ -22,7 +47,9 @@ export default function EventTypeSkeleton() {
                 <div
                   key={index}
                   className="group flex w-64 flex-row items-center rounded-md px-3 py-[10px] text-sm font-medium leading-none">
-                  <SkeletonAvatar className="mr-3 h-4 w-4" />
+                  <div className="mr-3 h-4 w-4">
+                    <SkeletonAvatar className="h-4 w-4" />
+                  </div>
                   <div className="flex w-full flex-col">
                     <SkeletonText className="h-4 w-24" />
                     <SkeletonText className="mt-1 h-3 w-16" />
@@ -41,17 +68,41 @@ export default function EventTypeSkeleton() {
 
               <div className="mb-6 space-y-6">
                 {/* Form fields */}
-                {Array.from({ length: 5 }).map((_, index) => (
-                  <div key={index} className="flex flex-col space-y-2">
-                    <SkeletonText className="h-4 w-32" />
+                <div className="flex flex-col space-y-2">
+                  <SkeletonText className="h-4 w-32" />
+                  <SkeletonText className="h-10 w-full" />
+                </div>
+
+                <div className="flex flex-col space-y-2">
+                  <SkeletonText className="h-4 w-40" />
+                  <div className="flex items-center">
                     <SkeletonText className="h-10 w-full" />
+                    <SkeletonButton className="ml-2 h-10 w-10 rounded-md" />
                   </div>
-                ))}
+                </div>
+
+                <div className="flex flex-col space-y-2">
+                  <SkeletonText className="h-4 w-36" />
+                  <SkeletonText className="h-24 w-full" />
+                </div>
+
+                <div className="flex flex-col space-y-2">
+                  <SkeletonText className="h-4 w-28" />
+                  <div className="flex items-center">
+                    <SkeletonText className="h-10 w-full" />
+                    <SkeletonButton className="ml-2 h-10 w-10 rounded-md" />
+                  </div>
+                </div>
+
+                <div className="flex flex-col space-y-2">
+                  <SkeletonText className="h-4 w-32" />
+                  <SkeletonText className="h-10 w-full" />
+                </div>
               </div>
 
               <div className="flex justify-end space-x-2">
-                <SkeletonText className="h-10 w-20" />
-                <SkeletonText className="h-10 w-20" />
+                <SkeletonButton className="h-10 w-24 rounded-md" />
+                <SkeletonButton className="h-10 w-24 rounded-md" />
               </div>
             </SkeletonContainer>
           </div>

--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-skeleton.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-skeleton.tsx
@@ -62,7 +62,9 @@ export default function EventTypeSkeleton() {
       heading={<SkeletonText className="hidden h-8 w-48" />}
       subtitle={<SkeletonText className="hidden h-4 w-24" />}
       afterHeading={desktopHeaderSkeleton}
-      smallHeading={mobileHeaderSkeleton}>
+      smallHeading={true}>
+      {/* Mobile header - only shown on small screens */}
+      <div className="mb-4 block md:hidden">{mobileHeaderSkeleton}</div>
       <div className="flex flex-col xl:flex-row xl:space-x-6">
         {/* Vertical tabs for desktop */}
         <div className="hidden xl:block">

--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-skeleton.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-skeleton.tsx
@@ -12,7 +12,19 @@ import {
 export default function EventTypeSkeleton() {
   const { t } = useLocale();
 
-  const backButtonSkeleton = (
+  const mobileHeaderSkeleton = (
+    <div className="flex w-full items-center justify-between space-x-2 rtl:space-x-reverse">
+      <div className="flex items-center space-x-2 rtl:space-x-reverse">
+        <SkeletonButton className="h-8 w-8 rounded-md" />
+      </div>
+      <div className="flex items-center space-x-2 rtl:space-x-reverse">
+        <SkeletonButton className="h-8 w-8 rounded-md" />
+        <SkeletonButton className="h-8 w-20 rounded-md" />
+      </div>
+    </div>
+  );
+
+  const desktopHeaderSkeleton = (
     <div className="bg-default sticky top-0 z-10 mb-0 flex items-center py-2 md:mb-6 md:mt-0">
       <div className="rounded-md ltr:mr-2 rtl:ml-2">
         <SkeletonButton className="h-8 w-8 rounded-md" />
@@ -24,10 +36,22 @@ export default function EventTypeSkeleton() {
       <div className="flex items-center gap-2">
         <SkeletonButton className="h-9 w-9 rounded-md" />
         <SkeletonButton className="h-9 w-9 rounded-md" />
-        <div className="flex space-x-2 rtl:space-x-reverse">
+        <div className="hidden space-x-2 rtl:space-x-reverse md:flex">
           <SkeletonButton className="h-9 w-24 rounded-md" />
           <SkeletonButton className="h-9 w-24 rounded-md" />
         </div>
+      </div>
+    </div>
+  );
+
+  const horizontalTabsSkeleton = (
+    <div className="mb-4 hidden md:block xl:hidden">
+      <div className="no-scrollbar flex flex-nowrap space-x-2 overflow-x-auto rtl:space-x-reverse">
+        {Array.from({ length: 8 }).map((_, index) => (
+          <div key={index} className="min-w-fit rounded-md px-4 py-2.5">
+            <SkeletonText className="h-4 w-24" />
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -37,15 +61,17 @@ export default function EventTypeSkeleton() {
       title={t("event_type_skeleton")}
       heading={<SkeletonText className="hidden h-8 w-48" />}
       subtitle={<SkeletonText className="hidden h-4 w-24" />}
-      afterHeading={backButtonSkeleton}>
+      afterHeading={desktopHeaderSkeleton}
+      smallHeading={mobileHeaderSkeleton}>
       <div className="flex flex-col xl:flex-row xl:space-x-6">
+        {/* Vertical tabs for desktop */}
         <div className="hidden xl:block">
           <div className="primary-navigation w-64 flex-shrink-0">
             <div className="flex flex-col space-y-1">
               {/* Tab navigation items */}
               {Array.from({ length: 8 }).map((_, index) => (
                 <div
-                  key={index}
+                  key={`vertical-${index}`}
                   className="group flex w-64 flex-row items-center rounded-md px-3 py-[10px] text-sm font-medium leading-none">
                   <div className="mr-3 h-4 w-4">
                     <SkeletonAvatar className="h-4 w-4" />
@@ -59,6 +85,10 @@ export default function EventTypeSkeleton() {
             </div>
           </div>
         </div>
+
+        {/* Horizontal tabs for medium screens */}
+        {horizontalTabsSkeleton}
+
         <div className="w-full ltr:mr-2 rtl:ml-2">
           <div className="bg-default border-subtle mt-4 rounded-md sm:mx-0 md:border md:p-6 xl:mt-0">
             <SkeletonContainer>

--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-skeleton.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-skeleton.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Shell from "@calcom/features/shell/Shell";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { SkeletonContainer, SkeletonText, SkeletonAvatar } from "@calcom/ui/components/skeleton";
+
+export default function EventTypeSkeleton() {
+  const { t } = useLocale();
+
+  return (
+    <Shell
+      title={t("event_type_skeleton")}
+      heading={<SkeletonText className="h-8 w-48" />}
+      subtitle={<SkeletonText className="h-4 w-24" />}
+      backPath="/event-types">
+      <div className="flex flex-col xl:flex-row xl:space-x-6">
+        <div className="hidden xl:block">
+          <div className="primary-navigation w-64 flex-shrink-0">
+            <div className="flex flex-col space-y-1">
+              {/* Tab navigation items */}
+              {Array.from({ length: 8 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="group flex w-64 flex-row items-center rounded-md px-3 py-[10px] text-sm font-medium leading-none">
+                  <SkeletonAvatar className="mr-3 h-4 w-4" />
+                  <div className="flex w-full flex-col">
+                    <SkeletonText className="h-4 w-24" />
+                    <SkeletonText className="mt-1 h-3 w-16" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="w-full ltr:mr-2 rtl:ml-2">
+          <div className="bg-default border-subtle mt-4 rounded-md sm:mx-0 md:border md:p-6 xl:mt-0">
+            <SkeletonContainer>
+              <div className="mb-8">
+                <SkeletonText className="h-8 w-full max-w-md" />
+              </div>
+
+              <div className="mb-6 space-y-6">
+                {/* Form fields */}
+                {Array.from({ length: 5 }).map((_, index) => (
+                  <div key={index} className="flex flex-col space-y-2">
+                    <SkeletonText className="h-4 w-32" />
+                    <SkeletonText className="h-10 w-full" />
+                  </div>
+                ))}
+              </div>
+
+              <div className="flex justify-end space-x-2">
+                <SkeletonText className="h-10 w-20" />
+                <SkeletonText className="h-10 w-20" />
+              </div>
+            </SkeletonContainer>
+          </div>
+        </div>
+      </div>
+    </Shell>
+  );
+}

--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-skeleton.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/event-type-skeleton.tsx
@@ -12,60 +12,28 @@ import {
 export default function EventTypeSkeleton() {
   const { t } = useLocale();
 
-  const mobileHeaderSkeleton = (
-    <div className="flex w-full items-center justify-between space-x-2 rtl:space-x-reverse">
-      <div className="flex items-center space-x-2 rtl:space-x-reverse">
-        <SkeletonButton className="h-8 w-8 rounded-md" />
-      </div>
-      <div className="flex items-center space-x-2 rtl:space-x-reverse">
-        <SkeletonButton className="h-8 w-8 rounded-md" />
-        <SkeletonButton className="h-8 w-20 rounded-md" />
-      </div>
-    </div>
-  );
-
-  const desktopHeaderSkeleton = (
-    <div className="bg-default sticky top-0 z-10 mb-0 flex items-center py-2 md:mb-6 md:mt-0">
-      <div className="rounded-md ltr:mr-2 rtl:ml-2">
-        <SkeletonButton className="h-8 w-8 rounded-md" />
-      </div>
-      <div className="w-full truncate ltr:mr-4 rtl:ml-4 md:block">
-        <SkeletonText className="h-8 w-48" />
-        <SkeletonText className="mt-1 h-4 w-24" />
-      </div>
-      <div className="flex items-center gap-2">
-        <SkeletonButton className="h-9 w-9 rounded-md" />
-        <SkeletonButton className="h-9 w-9 rounded-md" />
-        <div className="hidden space-x-2 rtl:space-x-reverse md:flex">
-          <SkeletonButton className="h-9 w-24 rounded-md" />
-          <SkeletonButton className="h-9 w-24 rounded-md" />
-        </div>
-      </div>
-    </div>
-  );
-
-  const horizontalTabsSkeleton = (
-    <div className="mb-4 hidden md:block xl:hidden">
-      <div className="no-scrollbar flex flex-nowrap space-x-2 overflow-x-auto rtl:space-x-reverse">
-        {Array.from({ length: 8 }).map((_, index) => (
-          <div key={index} className="min-w-fit rounded-md px-4 py-2.5">
-            <SkeletonText className="h-4 w-24" />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-
   return (
-    <Shell
-      title={t("event_type_skeleton")}
-      heading={<SkeletonText className="hidden h-8 w-48" />}
-      subtitle={<SkeletonText className="hidden h-4 w-24" />}
-      afterHeading={desktopHeaderSkeleton}
-      smallHeading={true}>
-      {/* Mobile header - only shown on small screens */}
-      <div className="mb-4 block md:hidden">{mobileHeaderSkeleton}</div>
+    <Shell title={t("event_type_skeleton")} smallHeading={true}>
       <div className="flex flex-col xl:flex-row xl:space-x-6">
+        {/* Desktop header - shown on all screens */}
+        <div className="bg-default sticky top-0 z-10 mb-0 flex w-full items-center py-2 md:mb-6 md:mt-0">
+          <div className="rounded-md ltr:mr-2 rtl:ml-2">
+            <SkeletonButton className="h-8 w-8 rounded-md" />
+          </div>
+          <div className="w-full truncate ltr:mr-4 rtl:ml-4 md:block">
+            <SkeletonText className="h-8 w-48" />
+            <SkeletonText className="mt-1 h-4 w-24" />
+          </div>
+          <div className="flex items-center gap-2">
+            <SkeletonButton className="h-9 w-9 rounded-md" />
+            <SkeletonButton className="h-9 w-9 rounded-md" />
+            <div className="hidden space-x-2 rtl:space-x-reverse md:flex">
+              <SkeletonButton className="h-9 w-24 rounded-md" />
+              <SkeletonButton className="h-9 w-24 rounded-md" />
+            </div>
+          </div>
+        </div>
+
         {/* Vertical tabs for desktop */}
         <div className="hidden xl:block">
           <div className="primary-navigation w-64 flex-shrink-0">
@@ -89,7 +57,28 @@ export default function EventTypeSkeleton() {
         </div>
 
         {/* Horizontal tabs for medium screens */}
-        {horizontalTabsSkeleton}
+        <div className="mb-4 hidden md:block xl:hidden">
+          <div className="no-scrollbar flex flex-nowrap space-x-2 overflow-x-auto rtl:space-x-reverse">
+            {Array.from({ length: 8 }).map((_, index) => (
+              <div key={index} className="min-w-fit rounded-md px-4 py-2.5">
+                <SkeletonText className="h-4 w-24" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Mobile header - only shown on small screens */}
+        <div className="mb-4 block md:hidden">
+          <div className="flex w-full items-center justify-between space-x-2 rtl:space-x-reverse">
+            <div className="flex items-center space-x-2 rtl:space-x-reverse">
+              <SkeletonButton className="h-8 w-8 rounded-md" />
+            </div>
+            <div className="flex items-center space-x-2 rtl:space-x-reverse">
+              <SkeletonButton className="h-8 w-8 rounded-md" />
+              <SkeletonButton className="h-8 w-20 rounded-md" />
+            </div>
+          </div>
+        </div>
 
         <div className="w-full ltr:mr-2 rtl:ml-2">
           <div className="bg-default border-subtle mt-4 rounded-md sm:mx-0 md:border md:p-6 xl:mt-0">

--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/page-wrapper.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/page-wrapper.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { EventTypeWebWrapper } from "@calcom/atoms/event-types/wrappers/EventTypeWebWrapper";
+
+import type { PageProps } from "@lib/event-types/[type]/getServerSideProps";
+
+const EventTypePageWrapper = ({ type, data }: PageProps) => {
+  return <EventTypeWebWrapper data={data} id={type} />;
+};
+
+export default EventTypePageWrapper;

--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/page-wrapper.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/page-wrapper.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { EventTypeWebWrapper } from "@calcom/atoms/event-types/wrappers/EventTypeWebWrapper";
-
 import type { PageProps } from "@lib/event-types/[type]/getServerSideProps";
 
+import EventTypePage from "./event-type-page";
+
 const EventTypePageWrapper = ({ type, data }: PageProps) => {
-  return <EventTypeWebWrapper data={data} id={type} />;
+  return <EventTypePage id={type} data={data} />;
 };
 
 export default EventTypePageWrapper;

--- a/apps/web/app/(use-page-wrapper)/event-types/[type]/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/event-types/[type]/page.tsx
@@ -1,6 +1,7 @@
 import type { PageProps as _PageProps } from "app/_types";
 import { _generateMetadata } from "app/_utils";
 import { cookies, headers } from "next/headers";
+import { Suspense } from "react";
 import { z } from "zod";
 
 import { EventTypeRepository } from "@calcom/lib/server/repository/eventType";
@@ -9,6 +10,8 @@ import { buildLegacyCtx } from "@lib/buildLegacyCtx";
 import { getServerSideProps } from "@lib/event-types/[type]/getServerSideProps";
 
 import EventTypePageWrapper from "~/event-types/views/event-types-single-view";
+
+import EventTypeSkeleton from "./event-type-skeleton";
 
 const querySchema = z.object({
   type: z
@@ -48,7 +51,11 @@ const ServerPage = async ({ params, searchParams }: _PageProps) => {
   const legacyCtx = buildLegacyCtx(await headers(), await cookies(), await params, await searchParams);
   const props = await getServerSideProps(legacyCtx);
 
-  return <EventTypePageWrapper {...props} />;
+  return (
+    <Suspense fallback={<EventTypeSkeleton />}>
+      <EventTypePageWrapper {...props} />
+    </Suspense>
+  );
 };
 
 export default ServerPage;

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -164,6 +164,7 @@
   "invitee_timezone": "Invitee Time Zone",
   "time_left": "Time left",
   "event_type": "Event Type",
+  "event_type_skeleton": "Event Type Loading",
   "duplicate_event_type": "Duplicate Event Type",
   "enter_meeting": "Enter Meeting",
   "video_call_provider": "Video call provider",


### PR DESCRIPTION
Added a loading skeleton for the event type page to show placeholders for navigation, forms, and buttons while content loads.

**New Features**
- Displays a responsive skeleton UI matching the event type page layout.
- Shows placeholder navigation, headers, and form fields during data fetching.